### PR TITLE
- bump PHP to 8.2.0 and Composer to 2.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG PHP_VERSION=8.1.12-fpm-alpine
-ARG COMPOSER_TAG_VERSION=2.4.4-bin
+ARG PHP_VERSION=8.2.0-fpm-alpine
+ARG COMPOSER_TAG_VERSION=2.5.1-bin
 
 FROM composer/composer:${COMPOSER_TAG_VERSION} AS composer_binary
 


### PR DESCRIPTION
Updates:

| package  | current | proposed |
| --- | --- | --- |
| **PHP** | 8.1.12 | 8.2.0 |
| **Composer** | 2.4.4 | 2.5.1 |

Changelog:
* https://www.php.net/ChangeLog-8.php#PHP_8_2
* https://www.php.net/ChangeLog-8.php#8.1.12
* https://getcomposer.org/changelog/2.5.1
* https://getcomposer.org/changelog/2.5.0

Readlist:
* https://www.php.net/releases/8.2/en.php