### PR TITLE
- bump PHP to 8.2.10 and Composer to 2.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG PHP_VERSION=8.2.0-fpm-alpine
-ARG COMPOSER_TAG_VERSION=2.5.1-bin
+ARG PHP_VERSION=8.2.10-fpm-alpine
+ARG COMPOSER_TAG_VERSION=2.6.3-bin
 
 FROM composer/composer:${COMPOSER_TAG_VERSION} AS composer_binary
 


### PR DESCRIPTION
Updates:

| package  | current | proposed |
| --- | --- | --- |
| **PHP** | 8.2.0 | 8.2.10 |
| **Composer** | 2.5.1 | 2.6.3 |

Changelog:
* https://www.php.net/ChangeLog-8.php#8.2.10
* https://www.php.net/ChangeLog-8.php#8.2.9
* https://www.php.net/ChangeLog-8.php#8.2.8
* https://www.php.net/ChangeLog-8.php#8.2.7
* https://www.php.net/ChangeLog-8.php#8.2.6
* https://www.php.net/ChangeLog-8.php#8.2.5
* https://www.php.net/ChangeLog-8.php#8.2.4
* https://www.php.net/ChangeLog-8.php#8.2.3
* https://www.php.net/ChangeLog-8.php#8.2.2
* https://www.php.net/ChangeLog-8.php#8.2.1
* https://getcomposer.org/changelog/2.6.3
* https://getcomposer.org/changelog/2.6.2
* https://getcomposer.org/changelog/2.6.1
* https://getcomposer.org/changelog/2.6.0
* https://getcomposer.org/changelog/2.5.8
* https://getcomposer.org/changelog/2.5.7
* https://getcomposer.org/changelog/2.5.6
* https://getcomposer.org/changelog/2.5.5
* https://getcomposer.org/changelog/2.5.4
* https://getcomposer.org/changelog/2.5.3
* https://getcomposer.org/changelog/2.5.2
