### PR TITLE
- bump PHP to 8.3.1 and Composer to 2.6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG PHP_VERSION=8.2.10-fpm-alpine
-ARG COMPOSER_TAG_VERSION=2.6.3-bin
+ARG PHP_VERSION=8.3.1-fpm-alpine
+ARG COMPOSER_TAG_VERSION=2.6.6-bin
 
 FROM composer/composer:${COMPOSER_TAG_VERSION} AS composer_binary
 


### PR DESCRIPTION
| Package  | Current | Proposed |
| ------------- | ------------- | ------------- |
| PHP  | 8.2.10  | 8.3.1|
| Composer  | 2.6.3 | 2.6.6 |

PHP changelog:
- https://www.php.net/ChangeLog-8.php#8.3.1
- https://www.php.net/ChangeLog-8.php#8.3.0
- https://www.php.net/ChangeLog-8.php#8.2.14
- https://www.php.net/ChangeLog-8.php#8.2.13
- https://www.php.net/ChangeLog-8.php#8.2.12
- https://www.php.net/ChangeLog-8.php#8.2.11

Composer changelog:
- https://getcomposer.org/changelog/2.6.6
- https://getcomposer.org/changelog/2.6.5
- https://getcomposer.org/changelog/2.6.4

Xdebug Supported Versions and Compatibility:
- https://xdebug.org/docs/compat